### PR TITLE
Increase required version of esp-idf to 3.0

### DIFF
--- a/doc/BUILD.md
+++ b/doc/BUILD.md
@@ -7,15 +7,15 @@ Please be warned that we cannot provide any support or warranty as soon as you u
 * [http://esp-idf.readthedocs.io/en/latest/windows-setup.html](http://esp-idf.readthedocs.io/en/latest/windows-setup.html)
 
 ## getting the latest version
-Tested with ESP-IDF version 2.1:
+Tested with ESP-IDF version 3.0:
 ```
-git clone --recursive --branch release/v2.1 https://github.com/espressif/esp-idf.git
+git clone --recursive --branch release/v3.0 https://github.com/espressif/esp-idf.git
 git submodule update 
 ```
 
 ## build settings
 ### make menuconfig
-* Serial flasher config --> (COMx) Default serial port e.g. COM4 (you find on Windows COM port in device manager); you can use speeds up to 921600bps
+* Serial flasher config --> (COMx) Default serial port e.g. `COM4` on Windows (you find on Windows COM port in device manager), or `/dev/ttyUSB0` on Linux (look at /dev/tty*); you can use speeds up to 921600bps
 * Component config --> ESP32-specific --> (10) Task watchdog timeout (seconds)
 * Component config --> ESP32-specific --> Core dump destination --> Flash
 * Partition table --> Custom parition table --> partitions.csv


### PR DESCRIPTION
It seems the struct `esp_wpa2_config_t` was added only in release 3.0, but is used in Wifi.cpp, so `BUILD.md` should state this version.

Currently building with v2.1 fails with:

```
CXX HttpResponse.o
CXX Wifi.o
/opt/dynaTrace/ufo/ufo-esp32/main/./Wifi.cpp: In member function 'void Wifi::Connect()':
/opt/dynaTrace/ufo/ufo-esp32/main/./Wifi.cpp:145:3: error: 'esp_wpa2_config_t' was not declared in this scope
   esp_wpa2_config_t ent_config = WPA2_CONFIG_INIT_DEFAULT();
   ^
/opt/dynaTrace/ufo/ufo-esp32/main/./Wifi.cpp:152:33: error: 'ent_config' was not declared in this scope
   esp_wifi_sta_wpa2_ent_enable(&ent_config);
                                 ^
/opt/dynaTrace/ufo/esp-idf/make/component_wrapper.mk:210: die Regel für Ziel „Wifi.o“ scheiterte
make[1]: *** [Wifi.o] Fehler 1
/opt/dynaTrace/ufo/esp-idf/make/project.mk:386: die Regel für Ziel „main-build“ scheiterte
make: *** [main-build] Fehler 2
```